### PR TITLE
Add recount subsampling script and results

### DIFF
--- a/11-subsample_recount_PLIER.R
+++ b/11-subsample_recount_PLIER.R
@@ -1,0 +1,109 @@
+# J. Taroni 2018
+# Subsample recount2 to the same size as the SLE WB compendium & train PLIER
+#
+# Is the magic (i.e., performance gains over the SLE WB compendium) the *size* 
+# of the recount2 compendium or the *heterogeneity* of the underlying samples
+# and conditions?
+#
+# We can train PLIER models on a subset of the recount2 compendium that is the
+# same size as the SLE WB compendium (n = 1640) to get at this question. We'll
+# do that 10x here and we'll run this from the command line rather than using a 
+# notebook due to its computationally intensive nature.
+#
+# USAGE: Rscript 11-subsample_recount_PLIER.R
+#
+
+# set seed for reproducibility
+set.seed(123)
+
+# results directory
+results.dir <- file.path("results", "11")
+dir.create(results.dir, recursive = TRUE, showWarnings = FALSE)
+
+# #### functions -----------------------------------------------------------------
+
+PLIERWrapper <- function(exprs, pathway.mat, seed = 12345) {
+  # "Pared down" PLIER wrapper function. The one we use elsewhere includes
+  # collapsing to common genes between the expression matrix and the gene sets
+  # that are included with the PLIER package -- we already have this information
+  # for this experiment
+  #
+  # Args:
+  #   exprs: a gene expression matrix, rows are genes, columns are samples
+  #   pathway.mat: combined pathway matrix for use with PLIER, same
+  #                genes and ordering as exprs
+  #   seed: an integer to be supplied to set.seed() for reproducibility 
+  #         purposes, default is 12345
+  # 
+  # Returns
+  #   a list that contains the row-normalized expression data and the PLIER
+  #   output
+
+  # trouble with glmnet otherwise
+  library(PLIER)
+  
+  set.seed(seed)
+
+  # check row order of expression and pathway matrices
+  ord.row.check <- all.equal(rownames(exprs), rownames(pathway.mat))
+  if (ord.row.check != TRUE) {
+    stop("rownames for exprs and pathway.mat should be the same.")
+  }
+  
+  # rescale
+  exprs <- PLIER::rowNorm(exprs)
+
+  # what should we set the minimum k parameter to in PLIER? estimate the number
+  # of PC for the SVD decomposition
+  set.k <- PLIER::num.pc(exprs)
+  
+  # PLIER main function + return results
+  plier.res <- PLIER::PLIER(as.matrix(exprs), as.matrix(pathway.mat),
+                            k = round((set.k + set.k * 0.3), 0), trace = TRUE)
+  return(list("exprs" = exprs,
+              "PLIER" = plier.res))
+
+}
+
+#### main ----------------------------------------------------------------------
+
+# get a vector of 10 random seeds
+seeds <- sample(1:10000, 10)
+
+# read in recount2 data -- this will be a list that contains the
+# recount2 expression matrix (RPKM), the gene set matrix, and the number
+# of significant PCs for the entire gene expression matrix (k)
+# k is no longer relevant here and will need to be recalculated
+recount.file <- file.path("data", "recount2_PLIER_data", 
+                          "recount_data_prep_PLIER.RDS")
+recount.data.list <- readRDS(recount.file)
+
+# how many total samples are in the recount2 compendium we're using?
+num.cols <- ncol(recount.data.list$rpkm.cm)
+
+# repeat this subsampling experiment 10x
+for (seed in seeds) {
+  
+  # message for a little transparency!
+  cat(paste("\n\nPerforming subsampling for seed:", seed, "\n\n\n"))
+  
+  # set seed -- we'll use this one for the sampling of column indices 
+  # and as an argument to PLIERWrapper()
+  set.seed(seed)
+
+  # index of samples to include
+  sample.index <- sample(1:num.cols, 1640)  # the number of SLE samples
+  
+  # expression matrix n = 1640
+  smpl.exprs <- recount.data.list$rpkm.cm[, sample.index]
+  
+  # rescaled exprs data & PLIER model
+  smpl.res <- PLIERWrapper(exprs = smpl.exprs,
+                           pathway.mat = recount.data.list$all.paths.cm,
+                           seed = seed)
+  
+  # save to file in the results directory
+  smpl.file <- file.path(results.dir, 
+                         paste0("recount2_subsampled_", seed, ".RDS"))
+  saveRDS(object = smpl.res, file = smpl.file)
+}

--- a/results/11/recount2_subsampled_2876.RDS
+++ b/results/11/recount2_subsampled_2876.RDS
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b96a6a0f8e522debcc589c44ed82089ff28d52ead2bed86ec948bfc453adf83d
+size 171745410

--- a/results/11/recount2_subsampled_4089.RDS
+++ b/results/11/recount2_subsampled_4089.RDS
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0bed3f2cb842676aa86e0f81050d20ee82139d5a46788ee6979d75ad1ae3d675
+size 173167254

--- a/results/11/recount2_subsampled_456.RDS
+++ b/results/11/recount2_subsampled_456.RDS
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e24d021e8b9d092d7e38e856d099221d71dcdf624cd0f34e8851d6e4e6ce5bc
+size 172608719

--- a/results/11/recount2_subsampled_4563.RDS
+++ b/results/11/recount2_subsampled_4563.RDS
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d3486ae97ce2f4602deffe1dadf611dd4fef0c8889f714ae61beceb38a95cdf
+size 172925329

--- a/results/11/recount2_subsampled_5278.RDS
+++ b/results/11/recount2_subsampled_5278.RDS
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cea8520d420002e2d89c3f143f3169c261bca019e40bcd28c0baa22107f77a94
+size 172580230

--- a/results/11/recount2_subsampled_5510.RDS
+++ b/results/11/recount2_subsampled_5510.RDS
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a09b1a4c0b9a14503a085ee0fa53cfeec4af8db6f0047d752720146424c8aa31
+size 173163328

--- a/results/11/recount2_subsampled_7883.RDS
+++ b/results/11/recount2_subsampled_7883.RDS
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e89ddd8cda5dd1e064ede17acc3b145dcd4c792af67faaa3190579e0e4dcafb
+size 172885675

--- a/results/11/recount2_subsampled_8828.RDS
+++ b/results/11/recount2_subsampled_8828.RDS
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b1b73803b7a72a7a35495a9a75a514a6c30e6c4fee1f62aef61bc5a7aff1464
+size 171249091

--- a/results/11/recount2_subsampled_8918.RDS
+++ b/results/11/recount2_subsampled_8918.RDS
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:726a98ed88bb16416d697e9fbbb50022dc901ac8c0ee27af0cec352c1707e919
+size 172345139

--- a/results/11/recount2_subsampled_9401.RDS
+++ b/results/11/recount2_subsampled_9401.RDS
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd3736890b0628af4d1a8de322acee085564a69bcb4517bc5b27c7a680bc5388
+size 172524819


### PR DESCRIPTION
The PLIER model trained on the recount2 data has similar or better performance than the model trained on the SLE WB compendium. We've performed evaluations such as the proportion of input pathways that are significantly associated with an LV, prediction of neutrophil count, and capturing both of the major types of IFN.

This comparable or greater performance could be solely attributed to the _size_ of the recount2 compendium, or it is possible that the _breadth of the biological conditions_ (e.g., more than one disease, multiple tissues) in the recount2 compendium plays a role.

In this PR, I'm adding a script that subsamples the recount2 compendium such that it contains the same number of samples as the SLE WB compendium (`n = 1640`) and trains a PLIER model. (The models themselves are also added here.) This is repeated 10 times. 

Couple caveats/points for discussion:
* The expression data I use for this experiment was prepped [here](https://github.com/greenelab/rheum-plier-data/blob/4be547553f24fecac9e2f5c2b469a17f9df253f0/recount2/2-prep_recount_for_plier.R). To summarize the pertinent bit, I scale (z-score) using the entire recount2 compendium (RPKM). I repeat the scaling [here](https://github.com/jaclyn-taroni/multi-plier/blob/0667ffa86e6ea32d45759fdd673898f5827cee34/11-subsample_recount_PLIER.R#L54). I suspect this isn't going to make a huge difference on the underlying models but thought it was worth noting.
* I'm randomly selecting the 1640 samples that are included. That is to say I am not selecting samples with the "breadth of biological conditions" in mind. Predicted phenotypes are available for the recount2 compendium ([Ellis, et al. _NAR._ 2018.](https://doi.org/10.1093/nar/gky102)). They could be potentially leveraged in the future. But it is probably worth poking around these models before making that decision.